### PR TITLE
Fix for conflict with depends="$token$"

### DIFF
--- a/src/appserver/static/tabs.css
+++ b/src/appserver/static/tabs.css
@@ -43,3 +43,7 @@
 .dashboard-panel[class*="dashboardPanel---pages-dark"] ul.nav-tabs li.active a {
 	color: #ffffff;
 }
+
+.row-hide {
+    display: none;
+}

--- a/src/appserver/static/tabs.js
+++ b/src/appserver/static/tabs.js
@@ -31,7 +31,7 @@ require(['jquery','underscore','splunkjs/mvc', 'bootstrap.tab', 'splunkjs/mvc/si
 			var targets = $(tabs[c]).data("elements").split(",");
 
 			for (var d = 0; d < targets.length; d++) {
-				$('#' + targets[d], this.$el).hide();
+				$('#' + targets[d], this.$el).addClass('row-hide');
 			}
 		}
 	};
@@ -111,7 +111,7 @@ require(['jquery','underscore','splunkjs/mvc', 'bootstrap.tab', 'splunkjs/mvc/si
 		for(var c = 0; c < toToggle.length; c++){
 			
 			// Show the items
-			$('#' + toToggle[c], this.$el).show();
+			$('#' + toToggle[c], this.$el).removeClass('row-hide');
 			
 			// Re-render the panels under the item if necessary
 			rerenderPanels(toToggle[c]);


### PR DESCRIPTION
Added a CSS class for hiding rows separate from the built-in hidden CSS class. Also changed the show/hide logic of the tabs to use removeClass("row-hide") and addClass("row-hide") instead of jQuery's show() and hide() methods. The show() and hide() methods insert inline styles into the dashboard rows which override the CSS hidden class added by depends="$token$".